### PR TITLE
Psyclone improvements

### DIFF
--- a/src/FortCL_stub.f90
+++ b/src/FortCL_stub.f90
@@ -93,3 +93,18 @@ contains
   end subroutine ocl_release
 
 end module fortcl
+
+! ==============================================================
+! PSyclone als uses the check_status function of ocl_utils_mod.
+! So provide a stub implementation in a separate module as well:
+module ocl_utils_mod
+
+  contains
+
+  subroutine check_status(text, ierr)
+    implicit none
+    character(len=*), intent(in) :: text
+    integer, intent(in) :: ierr
+  end subroutine check_status
+
+end module ocl_utils_mod

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,13 @@
 # Makefile for FortCL.
 
+F90 ?= gfortran
+
+# Get the absolute path to the makefile
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+# Then get the absolute path of the makefile directory,
+# which is the source directory.
+ROOT  := $(dir $(mkfile_path))
+
 # We don't include clfortran.o in the list of objects
 # because we don't want it in the final archive file.
 OBJECTS = ocl_params_mod.o ocl_utils_mod.o FortCL.o
@@ -9,16 +17,13 @@ all: ${LIB}
 
 # Target to build the library using just stub interfaces so as
 # to avoid any actual dependence on an OpenCL installation.
-stub: ocl_params_mod.o FortCL_stub.o
+stub: ocl_params_mod.o FortCL_stub.o clfortran.o
 	${AR} ${ARFLAGS} ${LIB} ocl_params_mod.o FortCL_stub.o
 
-${LIB}: clfortran ${OBJECTS}
+${LIB}: clfortran.o ${OBJECTS}
 	${AR} ${ARFLAGS} ${LIB} ${OBJECTS}
 
-clfortran:
-	${F90} -c clfortran.f90
-
-%.o: %.f90
+%.o: $(ROOT)/%.f90
 	${F90} ${F90FLAGS} -c $<
 
 clean:


### PR DESCRIPTION
Two changes:
1) A module was missing in the stub. I added the whole stub module (one function) to FortCL_stub - that's a bit of a hack (since now this one files creates two mod files, which I would typically avoid), on the other hand this way we have only one _stub file. Let me know what you prefer - one stub file, or each file creates only one module.

2) The makefile can now compile 'out of the src directory' (i.e. in separate build directories). This should not make a difference for FortCL, but it means in dl_esm_inf that the fortcl files can be compiled in the same directory as the dl_esm_inf files, which will make installation easier ... and that for PSyclone means that per-process compilation in different directories works out of the box.