### PR TITLE
Add environment variables to control runtime behavior (fixes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ variables. You will need to set F90 (and optionally, F90FLAGS).
 At link time you will need to link with the OpenCL run-time
 libraries on your system.
 
+# Controlling runtime behaviour"
+
+There are 3 environment variables to control the OpenCL execution
+at runtime:
+
+- `FORTCL_KERNELS_FILE`: Can point to a source code file to JIT
+compile it and use its kernels.
+
+- `FORTCL_PLATFORM`: If a system has multiple OpenCL platforms, this
+environment variable will choose which one to use. If not specified
+it will use platform 1.
+
+- `FORTCL_VERBOSE`: If this environment is set to a value different than
+0, it will produce a more verbose execution of FortCL.
+
 # Example #
 
 There are two examples in the `examples` directory but in short:

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ at runtime:
 source code filename containing the OpenCL kernels to execute.
 
 - `FORTCL_PLATFORM`: Integer that selects in which OpenCL platform the
-kernels are going to be executed (the list of OpenCL platforms can be
-queried with the `clinfo` command). If this variable is not set, the
-kernels will be launched on platform 1.
+kernels are going to be executed. The list of OpenCL platforms is a 
+1-based indexing list that can be queried with the `clinfo` command.
+If this variable is not set, the kernels will be launched on platform
+1 (first available).
 
 - `FORTCL_VERBOSE`: Boolean value to request more verbose information
 of the OpenCL runtime execution. It is considered true if this environment

--- a/README.md
+++ b/README.md
@@ -16,15 +16,17 @@ libraries on your system.
 There are 3 environment variables to control the OpenCL execution
 at runtime:
 
-- `FORTCL_KERNELS_FILE`: Specify at run-time the binary or source file
-where the OpenCL kernels are if this is not given at compile-time.
+- `FORTCL_KERNELS_FILE`: Allows to specify at run-time the binary or
+source code filename containing the OpenCL kernels to execute.
 
-- `FORTCL_PLATFORM`: If a system has multiple OpenCL platforms, this
-environment variable will choose which one to use. If not specified
-it will use platform 1.
+- `FORTCL_PLATFORM`: Integer that selects in which OpenCL platform the
+kernels are going to be executed (the list of OpenCL platforms can be
+queried with the `clinfo` command). If this variable is not set, the
+kernels will be launched on platform 1.
 
-- `FORTCL_VERBOSE`: If this environment is set to a value different than
-0, it will produce a more verbose execution of FortCL.
+- `FORTCL_VERBOSE`: Boolean value to request more verbose information
+of the OpenCL runtime execution. It is considered true if this environment
+variable exists and is set to a value other than 0.
 
 # Example #
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ libraries on your system.
 There are 3 environment variables to control the OpenCL execution
 at runtime:
 
-- `FORTCL_KERNELS_FILE`: Can point to a source code file to JIT
-compile it and use its kernels.
+- `FORTCL_KERNELS_FILE`: Specify at run-time the binary or source file
+where the OpenCL kernels are if this is not given at compile-time.
 
 - `FORTCL_PLATFORM`: If a system has multiple OpenCL platforms, this
 environment variable will choose which one to use. If not specified

--- a/src/FortCL.f90
+++ b/src/FortCL.f90
@@ -89,7 +89,7 @@ contains
     end if
 
     if(.not. present(filename))then
-       call get_environment_variable("PSYCLONE_KERNELS_FILE", lfilename)
+       call get_environment_variable("FORTCL_KERNELS_FILE", lfilename)
     else
        lfilename = filename
     end if

--- a/src/FortCL.f90
+++ b/src/FortCL.f90
@@ -152,7 +152,6 @@ contains
     !> \TODO is there a better way to do this that reduces the need for
     !! string comparisons?
     do ik = 1, cl_num_kernels
-       write(*,*) "kernel name: ", cl_kernel_names(ik)
        if(name == cl_kernel_names(ik))then
           ! We can't just return out of this loop because this is a
           ! function

--- a/src/ocl_utils_mod.f90
+++ b/src/ocl_utils_mod.f90
@@ -29,7 +29,6 @@ contains
        platform_ids(:), device_ids(:)
     character(len=1,kind=c_char), allocatable, target :: device_name(:)
     character(len=1) :: strvalue
-
     ! Set verbosity to false if FORTCL_VERBOSE does not exist (ierr is 1) or
     ! is equal to "0".
     CALL get_environment_variable("FORTCL_VERBOSE", strvalue, status=ierr)
@@ -67,9 +66,10 @@ contains
         if(ierr .ne. 0) then
             stop 'Error: Cannot convert FORTCL_PLATFORM value into an integer.'
         endif
-        if(iplatform > num_platforms) then
-            write(*,*) 'Error: Specified FORTCL_PLATFORM is bigger than the', &
-                       ' number of OpenCL platforms available.'
+        if(iplatform > num_platforms .or. iplatform .eq. 0) then
+            write(*,*) 'Error: FORTCL_PLATFORM should be a number between ', &
+                '1 and the number of platforms. Use `clinfo` to list the ', &
+                'available OpenCL platforms in the system.'
             stop
         endif
     endif

--- a/src/ocl_utils_mod.f90
+++ b/src/ocl_utils_mod.f90
@@ -4,6 +4,7 @@ module ocl_utils_mod
   implicit none
 
   integer, parameter :: CL_UTIL_STR_LEN = 64
+  logical :: verbose
 
   !> This interface lets us over-load read_buffer to take Fortran
   !! arrays of differing ranks.
@@ -27,6 +28,14 @@ contains
     integer(c_intptr_t), allocatable, target :: &
        platform_ids(:), device_ids(:)
     character(len=1,kind=c_char), allocatable, target :: device_name(:)
+
+    ! Just look if FORTCL_VERBOSE is set up (ierr == 0)
+    CALL get_environment_variable("FORTCL_VERBOSE", status=ierr)
+    if (ierr .eq. 0) then
+        verbose = .True.
+    else
+        verbose = .False.
+    endif
 
     num_platforms = 0
     ierr = clGetPlatformIDs(0, C_NULL_PTR, num_platforms)
@@ -364,7 +373,6 @@ contains
     character(len=*), intent(in) :: text
     integer, intent(in) :: ierr
 
-    logical, parameter :: verbose = .TRUE.
 
     if(ierr /= CL_SUCCESS)then
        write(*,'("Hit error: ",(A),": ",(A))') text, OCL_GetErrorString(ierr)

--- a/src/ocl_utils_mod.f90
+++ b/src/ocl_utils_mod.f90
@@ -61,9 +61,17 @@ contains
     CALL get_environment_variable("FORTCL_PLATFORM", strvalue, status=ierr)
     if(ierr .eq. 1) then
         ! By default use platform 1
-        iplatform=1
+        iplatform = 1
     else
-        read(strvalue,"(i1)") iplatform
+        read(strvalue,"(i1)", iostat=ierr) iplatform
+        if(ierr .ne. 0) then
+            stop 'Error: Cannot convert FORTCL_PLATFORM value into an integer.'
+        endif
+        if(iplatform > num_platforms) then
+            write(*,*) 'Error: Specified FORTCL_PLATFORM is bigger than the', &
+                       ' number of OpenCL platforms available.'
+            stop
+        endif
     endif
 
     ! Get device IDs only for the selected platform

--- a/src/ocl_utils_mod.f90
+++ b/src/ocl_utils_mod.f90
@@ -28,7 +28,7 @@ contains
     integer(c_intptr_t), allocatable, target :: &
        platform_ids(:), device_ids(:)
     character(len=1,kind=c_char), allocatable, target :: device_name(:)
-    character(len=1) :: strvalue
+    character(len=1) :: strvalue = ' '
     ! Set verbosity to false if FORTCL_VERBOSE does not exist (ierr is 1) or
     ! is equal to "0".
     CALL get_environment_variable("FORTCL_VERBOSE", strvalue, status=ierr)
@@ -66,7 +66,7 @@ contains
         if(ierr .ne. 0) then
             stop 'Error: Cannot convert FORTCL_PLATFORM value into an integer.'
         endif
-        if(iplatform > num_platforms .or. iplatform .eq. 0) then
+        if(iplatform > num_platforms .or. iplatform <= 0) then
             write(*,*) 'Error: FORTCL_PLATFORM should be a number between ', &
                 '1 and the number of platforms. Use `clinfo` to list the ', &
                 'available OpenCL platforms in the system.'


### PR DESCRIPTION
There is now 3 environment variables:
- FORTCL_PLATFORM: to select the platform when the system has multiple - this is necessary for the Intel OneAPI.

- FORTCL_VERBOSE: To make it more verbose (fixes #9) and improve NemoLite and Shallow benchmarks when they run many iterations.

- FORTCL_KERNELS_FILE: Renamed from PSYCLONE_KERNELS_FILE, to select the location of the kernels at run-time.